### PR TITLE
Closes #142; change address parameter to optional in fence agent calls

### DIFF
--- a/AN/Tools/ScanCore.pm
+++ b/AN/Tools/ScanCore.pm
@@ -6816,32 +6816,35 @@ sub target_power
 				name1 => "power_check", value1 => $power_check,
 			}, file => $THIS_FILE, line => __LINE__});
 			
-			$ipmi_target = ($power_check =~ /-a\s(.*?)\s/)[0];
-			$an->Log->entry({log_level => 3, message_key => "an_variables_0001", message_variables => {
-				name1 => "ipmi_target", value1 => $ipmi_target,
-			}, file => $THIS_FILE, line => __LINE__});
-			if (not $an->Validate->is_ipv4({ip => $ipmi_target}))
-			{
+			# Only do the IP address conversion if address is set.
+			if ($power_check =~ /-a\s/) {
+				$ipmi_target = ($power_check =~ /-a\s(.*?)\s/)[0];
 				$an->Log->entry({log_level => 3, message_key => "an_variables_0001", message_variables => {
 					name1 => "ipmi_target", value1 => $ipmi_target,
 				}, file => $THIS_FILE, line => __LINE__});
-				
-				print "$THIS_FILE ".__LINE__."; ipmi_target: [$ipmi_target]\n";
-				my $ip = $an->Get->ip({host => $ipmi_target});
-				$an->Log->entry({log_level => 3, message_key => "an_variables_0001", message_variables => {
-					name1 => "ip", value1 => $ip,
-				}, file => $THIS_FILE, line => __LINE__});
-				
-				if ($ip)
+				if (not $an->Validate->is_ipv4({ip => $ipmi_target}))
 				{
-					$an->Log->entry({log_level => 4, message_key => "an_variables_0001", message_variables => {
-						name1 => ">> power_check", value1 => $power_check,
+					$an->Log->entry({log_level => 3, message_key => "an_variables_0001", message_variables => {
+						name1 => "ipmi_target", value1 => $ipmi_target,
 					}, file => $THIS_FILE, line => __LINE__});
 					
-					$power_check =~ s/$ipmi_target/$ip/;
-					$an->Log->entry({log_level => 4, message_key => "an_variables_0001", message_variables => {
-						name1 => "<< power_check", value1 => $power_check,
+					print "$THIS_FILE ".__LINE__."; ipmi_target: [$ipmi_target]\n";
+					my $ip = $an->Get->ip({host => $ipmi_target});
+					$an->Log->entry({log_level => 3, message_key => "an_variables_0001", message_variables => {
+						name1 => "ip", value1 => $ip,
 					}, file => $THIS_FILE, line => __LINE__});
+					
+					if ($ip)
+					{
+						$an->Log->entry({log_level => 4, message_key => "an_variables_0001", message_variables => {
+							name1 => ">> power_check", value1 => $power_check,
+						}, file => $THIS_FILE, line => __LINE__});
+						
+						$power_check =~ s/$ipmi_target/$ip/;
+						$an->Log->entry({log_level => 4, message_key => "an_variables_0001", message_variables => {
+							name1 => "<< power_check", value1 => $power_check,
+						}, file => $THIS_FILE, line => __LINE__});
+					}
 				}
 			}
 			

--- a/AN/Tools/Striker.pm
+++ b/AN/Tools/Striker.pm
@@ -10754,7 +10754,8 @@ sub _parse_cluster_conf
 							}
 						}
 						
-						my $command  = "$agent -a $address ";
+						my $command  = "$agent ";
+						   $command .= "-a $address "         if $address; # fence_delay does not require an address.
 						   $command .= "-l $login "           if $login;
 						   $command .= "-P "                  if $lanplus;
 						   $command .= "-p \"$password\" "    if $password; # quote the password in case it has spaces in it.


### PR DESCRIPTION
In addition to the optional `-a`, there is a check added prior to address conversion (`AN::Tools::Get->ip`) to ensure there is an address to convert.

This PR does not include removal of the unnecessary port (`-n`) parameter to `fence_delay`.

After adding this update, `nodes_cache` with `node_cache_name='power_check'` in `scancore` DB must be cleared.

Note: please enable "Hide whitespace changes" (under the gear icon when on the [commit](https://github.com/ClusterLabs/striker/pull/143/commits/6262a3b4533faae5223f4752cf1258e63400a18e) page) to view the actual file changes in the commit.